### PR TITLE
Fix \yii\cache\SimpleCache::get() if the parameter to the `serializer` is set to false

### DIFF
--- a/src/SimpleCache.php
+++ b/src/SimpleCache.php
@@ -103,10 +103,12 @@ abstract class SimpleCache extends Component implements CacheInterface
     {
         $key = $this->normalizeKey($key);
         $value = $this->getValue($key);
-        if ($value === false || $this->_serializer === false) {
+        if ($value === false) {
             return $default;
         }
-
+        if ($this->_serializer === false) {
+            return $value;
+        }
         return $this->_serializer->unserialize($value);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes
| Tests pass?   | no
| Fixed issues  |
