### PR TITLE
Merge serializer

### DIFF
--- a/src/MemCached.php
+++ b/src/MemCached.php
@@ -7,7 +7,7 @@
 
 namespace Yiisoft\Cache;
 
-use yii\serialize\SerializerInterface;
+use Yiisoft\Cache\Serializer\SerializerInterface;
 use Yiisoft\Cache\Exceptions\InvalidConfigException;
 
 /**

--- a/src/Serializer/CallbackSerializer.php
+++ b/src/Serializer/CallbackSerializer.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace Yiisoft\Cache\Serializer;
+
+/**
+ * CallbackSerializer serializes data via custom PHP callback.
+ */
+class CallbackSerializer implements SerializerInterface
+{
+    /**
+     * @var callable PHP callback, which should be used to serialize value.
+     */
+    private $serialize;
+    /**
+     * @var callable PHP callback, which should be used to unserialize value.
+     */
+    private $unserialize;
+
+    public function __construct($serialize, $unserialize)
+    {
+        $this->serialize = $serialize;
+        $this->unserialize = $unserialize;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize($value): string
+    {
+        return call_user_func($this->serialize, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize(string $value)
+    {
+        return call_user_func($this->unserialize, $value);
+    }
+}

--- a/src/Serializer/IgbinarySerializer.php
+++ b/src/Serializer/IgbinarySerializer.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace Yiisoft\Cache\Serializer;
+
+/**
+ * IgbinarySerializer uses [Igbinary PHP extension](http://pecl.php.net/package/igbinary) for serialization.
+ * Make sure you have 'igbinary' PHP extension install at your system before attempt to use this serializer.
+ */
+class IgbinarySerializer implements SerializerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize($value): string
+    {
+        return igbinary_serialize($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize(string $value)
+    {
+        return igbinary_unserialize($value);
+    }
+}

--- a/src/Serializer/JsonSerializer.php
+++ b/src/Serializer/JsonSerializer.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace Yiisoft\Cache\Serializer;
+
+//use yii\helpers\Json;
+
+/**
+ * JsonSerializer serializes data in JSON format.
+ */
+class JsonSerializer implements SerializerInterface
+{
+    private $options;
+
+    /**
+     * JsonSerializer constructor.
+     *
+     * @param int $options integer the encoding options. For more details please refer to
+     * <http://www.php.net/manual/en/function.json-encode.php>.
+     * Default is `JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE`.
+     */
+    public function __construct($options = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+    {
+        $this->options = $options;
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize($value): string
+    {
+        return json_encode($value, $this->options); //FIXME: Json::encode($value, $this->options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize(string $value)
+    {
+        return json_decode($value, true); //FIXME: Json::decode($value);
+    }
+}

--- a/src/Serializer/PhpSerializer.php
+++ b/src/Serializer/PhpSerializer.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace Yiisoft\Cache\Serializer;
+
+/**
+ * PhpSerializer uses native PHP `serialize()` and `unserialize()` functions for the serialization.
+ */
+class PhpSerializer implements SerializerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize($value): string
+    {
+        return serialize($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize(string $value)
+    {
+        return unserialize($value);
+    }
+}

--- a/src/Serializer/SerializerInterface.php
+++ b/src/Serializer/SerializerInterface.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace Yiisoft\Cache\Serializer;
+
+/**
+ * SerializerInterface defines serializer interface.
+ */
+interface SerializerInterface
+{
+    /**
+     * Serializes given value.
+     * @param mixed $value value to be serialized
+     * @return string serialized value.
+     */
+    public function serialize($value): string;
+
+    /**
+     * Restores value from its serialized representations
+     * @param string $value serialized string.
+     * @return mixed restored value
+     */
+    public function unserialize(string $value);
+}

--- a/src/SimpleCache.php
+++ b/src/SimpleCache.php
@@ -10,8 +10,8 @@ namespace Yiisoft\Cache;
 use Psr\SimpleCache\CacheInterface;
 use yii\base\Component;
 use yii\helpers\Yii;
-use yii\serialize\PhpSerializer;
-use yii\serialize\SerializerInterface;
+use Yiisoft\Cache\Serializer\PhpSerializer;
+use Yiisoft\Cache\Serializer\SerializerInterface;
 
 /**
  * SimpleCache is the base class for cache classes implementing pure PSR-16 [[CacheInterface]].
@@ -71,7 +71,7 @@ abstract class SimpleCache extends Component implements CacheInterface
      *
      * ```php
      * [
-     *     '__class' => \yii\serialize\IgbinarySerializer::class
+     *     '__class' => \Yiisoft\Cache\Serializer\IgbinarySerializer::class
      * ]
      * ```
      *

--- a/tests/Serializer/CallbackSerializerTest.php
+++ b/tests/Serializer/CallbackSerializerTest.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace Yiisoft\Cache\Tests\Serializer;
+
+use Yiisoft\Cache\Serializer\CallbackSerializer;
+use Yiisoft\Cache\Serializer\SerializerInterface;
+
+/**
+ * @group serialize
+ */
+class CallbackSerializerTest extends SerializerTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function createSerializer(): SerializerInterface
+    {
+        return new CallbackSerializer('serialize','unserialize');
+    }
+}

--- a/tests/Serializer/CallbackSerializerTest.php
+++ b/tests/Serializer/CallbackSerializerTest.php
@@ -20,6 +20,6 @@ class CallbackSerializerTest extends SerializerTest
      */
     protected function createSerializer(): SerializerInterface
     {
-        return new CallbackSerializer('serialize','unserialize');
+        return new CallbackSerializer('serialize', 'unserialize');
     }
 }

--- a/tests/Serializer/IgbinarySerializerTest.php
+++ b/tests/Serializer/IgbinarySerializerTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace Yiisoft\Cache\Tests\Serializer;
+
+use Yiisoft\Cache\Serializer\IgbinarySerializer;
+use Yiisoft\Cache\Serializer\SerializerInterface;
+
+/**
+ * @group serialize
+ */
+class IgbinarySerializerTest extends SerializerTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        if (!function_exists('igbinary_serialize')) {
+            $this->markTestSkipped('igbinary extension is required.');
+            return;
+        }
+
+        parent::setUp();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createSerializer(): SerializerInterface
+    {
+        return new IgbinarySerializer();
+    }
+}

--- a/tests/Serializer/JsonSerializerTest.php
+++ b/tests/Serializer/JsonSerializerTest.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace Yiisoft\Cache\Tests\Serializer;
+
+use Yiisoft\Cache\Serializer\JsonSerializer;
+use Yiisoft\Cache\Serializer\SerializerInterface;
+
+/**
+ * @group serialize
+ */
+class JsonSerializerTest extends SerializerTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function createSerializer(): SerializerInterface
+    {
+        return new JsonSerializer();
+    }
+}

--- a/tests/Serializer/PhpSerializerTest.php
+++ b/tests/Serializer/PhpSerializerTest.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace Yiisoft\Cache\Tests\Serializer;
+
+use Yiisoft\Cache\Serializer\PhpSerializer;
+use Yiisoft\Cache\Serializer\SerializerInterface;
+
+/**
+ * @group serialize
+ */
+class PhpSerializerTest extends SerializerTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function createSerializer(): SerializerInterface
+    {
+        return new PhpSerializer();
+    }
+}

--- a/tests/Serializer/SerializerTest.php
+++ b/tests/Serializer/SerializerTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace Yiisoft\Cache\Tests\Serializer;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Cache\Serializer\SerializerInterface;
+
+/**
+ * @group serialize
+ */
+abstract class SerializerTest extends TestCase
+{
+    /**
+     * Creates serializer instance for the tests.
+     * @return SerializerInterface
+     */
+    abstract protected function createSerializer(): SerializerInterface;
+
+    /**
+     * Data provider for [[testSerialize()]]
+     * @return array test data.
+     */
+    public function dataProviderSerialize(): array
+    {
+        return [
+            ['some-string'],
+            [345],
+            [56.89],
+            [['some' => 'array']],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderSerialize
+     *
+     * @param mixed $value
+     */
+    public function testSerialize($value): void
+    {
+        $serializer = $this->createSerializer();
+
+        $serialized = $serializer->serialize($value);
+        $this->assertIsString($serialized);
+
+        $this->assertEquals($value, $serializer->unserialize($serialized));
+    }
+}


### PR DESCRIPTION
Extracted yii\serializer from yiisoft/yii-core as it was only used in Cache.

We may want to rename current sub-packages to add the `handler` keyword:
  * cache-db => cache-handler-db
  * cache-apc => cache-handler-apc
  * cache-file => cache-handler-file
  * cache-memcached => cache-handler-memcached
  * cache-wincache => cache-handler-wincache

And extract the ig-binary serializer into `cache-serializer-igbinary`

Opinions? 