### PR TITLE
Fix phan issues

### DIFF
--- a/src/ArrayCache.php
+++ b/src/ArrayCache.php
@@ -67,7 +67,8 @@ final class ArrayCache implements CacheInterface
         $this->validateKeys($keys);
         $results = [];
         foreach ($keys as $key) {
-            $value = $this->get((string)$key, $default);
+            assert(is_string($key));
+            $value = $this->get($key, $default);
             $results[$key] = $value;
         }
         return $results;
@@ -88,7 +89,8 @@ final class ArrayCache implements CacheInterface
         $keys = $this->iterableToArray($keys);
         $this->validateKeys($keys);
         foreach ($keys as $key) {
-            $this->delete((string)$key);
+            assert(is_string($key));
+            $this->delete($key);
         }
         return true;
     }

--- a/src/ArrayCache.php
+++ b/src/ArrayCache.php
@@ -67,7 +67,7 @@ final class ArrayCache implements CacheInterface
         $this->validateKeys($keys);
         $results = [];
         foreach ($keys as $key) {
-            $value = $this->get($key, $default);
+            $value = $this->get((string)$key, $default);
             $results[$key] = $value;
         }
         return $results;
@@ -88,7 +88,7 @@ final class ArrayCache implements CacheInterface
         $keys = $this->iterableToArray($keys);
         $this->validateKeys($keys);
         foreach ($keys as $key) {
-            $this->delete($key);
+            $this->delete((string)$key);
         }
         return true;
     }
@@ -135,6 +135,7 @@ final class ArrayCache implements CacheInterface
      * Normalizes cache TTL handling strings and {@see DateInterval} objects.
      * @param int|string|DateInterval|null $ttl raw TTL.
      * @return int|null TTL value as UNIX timestamp or null meaning infinity
+     * @suppress PhanPossiblyFalseTypeReturn
      */
     private function normalizeTtl($ttl): ?int
     {

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -55,9 +55,6 @@ final class Cache implements CacheInterface
      */
     private $defaultTtl;
 
-    /**
-     * @param \Psr\SimpleCache\CacheInterface $handler cache handler.
-     */
     public function __construct(\Psr\SimpleCache\CacheInterface $handler)
     {
         $this->handler = $handler;
@@ -82,7 +79,7 @@ final class Cache implements CacheInterface
         } else {
             $jsonKey = json_encode($key);
             if ($jsonKey === false) {
-                throw new \Yiisoft\Cache\Exception\InvalidArgumentException('Invalid key.');
+                throw new \Yiisoft\Cache\Exception\InvalidArgumentException('Invalid key. ' . json_last_error_msg());
             }
             $normalizedKey = $this->keyPrefix . md5($jsonKey);
         }

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -114,6 +114,7 @@ final class Cache implements CacheInterface
      * is returned in terms of (key, value) pairs.
      * If a value is not cached or expired, the corresponding array value will be false.
      * @throws InvalidArgumentException
+     * @suppress PhanTypeInvalidThrowsIsInterface
      */
     public function getMultiple($keys, $default = null): iterable
     {
@@ -134,10 +135,11 @@ final class Cache implements CacheInterface
      * a complex data structure consisting of factors representing the key.
      * @param mixed $value the value to be cached
      * @param null|int|\DateInterval $ttl the TTL of this value. If not set, default value is used.
-     * @param Dependency $dependency dependency of the cached value. If the dependency changes,
+     * @param Dependency|null $dependency dependency of the cached value. If the dependency changes,
      * the corresponding value in the cache will be invalidated when it is fetched via {@see CacheInterface::get()}.
      * @return bool whether the value is successfully stored into cache
      * @throws InvalidArgumentException
+     * @suppress PhanTypeInvalidThrowsIsInterface
      */
     public function set($key, $value, $ttl = null, Dependency $dependency = null): bool
     {
@@ -156,10 +158,11 @@ final class Cache implements CacheInterface
      *
      * @param array $values the values to be cached, as key-value pairs.
      * @param null|int|\DateInterval $ttl the TTL value of this value. If not set, default value is used.
-     * @param Dependency $dependency dependency of the cached values. If the dependency changes,
+     * @param Dependency|null $dependency dependency of the cached values. If the dependency changes,
      * the corresponding values in the cache will be invalidated when it is fetched via {@see CacheInterface::get()}.
      * @return bool True on success and false on failure.
      * @throws InvalidArgumentException
+     * @suppress PhanTypeInvalidThrowsIsInterface
      */
     public function setMultiple($values, $ttl = null, Dependency $dependency = null): bool
     {
@@ -180,10 +183,11 @@ final class Cache implements CacheInterface
      *
      * @param array $values the values to be cached, as key-value pairs.
      * @param null|int|\DateInterval $ttl the TTL value of this value. If not set, default value is used.
-     * @param Dependency $dependency dependency of the cached values. If the dependency changes,
+     * @param Dependency|null $dependency dependency of the cached values. If the dependency changes,
      * the corresponding values in the cache will be invalidated when it is fetched via {@see CacheInterface::get()}.
      * @return bool
      * @throws InvalidArgumentException
+     * @suppress PhanTypeInvalidThrowsIsInterface
      */
     public function addMultiple(array $values, $ttl = null, Dependency $dependency = null): bool
     {
@@ -214,10 +218,11 @@ final class Cache implements CacheInterface
      * a complex data structure consisting of factors representing the key.
      * @param mixed $value the value to be cached
      * @param null|int|\DateInterval $ttl the TTL value of this value. If not set, default value is used.
-     * @param Dependency $dependency dependency of the cached value. If the dependency changes,
+     * @param Dependency|null $dependency dependency of the cached value. If the dependency changes,
      * the corresponding value in the cache will be invalidated when it is fetched via {@see CacheInterface::get()}.
      * @return bool whether the value is successfully stored into cache
      * @throws InvalidArgumentException
+     * @suppress PhanTypeInvalidThrowsIsInterface
      */
     public function add($key, $value, $ttl = null, Dependency $dependency = null): bool
     {
@@ -240,6 +245,7 @@ final class Cache implements CacheInterface
      * a complex data structure consisting of factors representing the key.
      * @return bool if no error happens during deletion
      * @throws InvalidArgumentException
+     * @suppress PhanTypeInvalidThrowsIsInterface
      */
     public function delete($key): bool
     {
@@ -279,11 +285,12 @@ final class Cache implements CacheInterface
      * @param callable|\Closure $callable the callable or closure that will be used to generate a value to be cached.
      * In case $callable returns `false`, the value will not be cached.
      * @param null|int|\DateInterval $ttl the TTL value of this value. If not set, default value is used.
-     * @param Dependency $dependency dependency of the cached value. If the dependency changes,
+     * @param Dependency|null $dependency dependency of the cached value. If the dependency changes,
      * the corresponding value in the cache will be invalidated when it is fetched via {@see CacheInterface::get()}.
      * @return mixed result of $callable execution
      * @throws SetCacheException
      * @throws InvalidArgumentException
+     * @suppress PhanTypeInvalidThrowsIsInterface
      */
     public function getOrSet($key, callable $callable, $ttl = null, Dependency $dependency = null)
     {

--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -52,7 +52,7 @@ interface CacheInterface extends \Psr\SimpleCache\CacheInterface
      * If the cache already contains such a key, the existing value and
      * expiration time will be replaced with the new ones, respectively.
      *
-     * @param array $values the values to be cached, as key-value pairs.
+     * @param iterable $values the values to be cached, as key-value pairs.
      * @param null|int|\DateInterval $ttl the TTL of this value. If not set, default value is used.
      * @param Dependency|null $dependency dependency of the cached values. If the dependency changes,
      * the corresponding values in the cache will be invalidated when it is fetched via {@see CacheInterface::get()}.

--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -41,7 +41,7 @@ interface CacheInterface extends \Psr\SimpleCache\CacheInterface
      * a complex data structure consisting of factors representing the key.
      * @param mixed $value the value to be cached
      * @param null|int|\DateInterval $ttl the TTL of this value. If not set, default value is used.
-     * @param Dependency $dependency dependency of the value. If the dependency changes,
+     * @param Dependency|null $dependency dependency of the value. If the dependency changes,
      * the corresponding value in the cache will be invalidated when it is fetched via {@see CacheInterface::get()}.
      * @return bool whether the value is successfully stored into cache
      */
@@ -54,7 +54,7 @@ interface CacheInterface extends \Psr\SimpleCache\CacheInterface
      *
      * @param array $values the values to be cached, as key-value pairs.
      * @param null|int|\DateInterval $ttl the TTL of this value. If not set, default value is used.
-     * @param Dependency $dependency dependency of the cached values. If the dependency changes,
+     * @param Dependency|null $dependency dependency of the cached values. If the dependency changes,
      * the corresponding values in the cache will be invalidated when it is fetched via {@see CacheInterface::get()}.
      * @return bool
      */
@@ -67,7 +67,7 @@ interface CacheInterface extends \Psr\SimpleCache\CacheInterface
      * a complex data structure consisting of factors representing the key.
      * @param mixed $value the value to be cached
      * @param null|int|\DateInterval $ttl the TTL of this value. If not set, default value is used.
-     * @param Dependency $dependency dependency of the value. If the dependency changes,
+     * @param Dependency|null $dependency dependency of the value. If the dependency changes,
      * the corresponding value in the cache will be invalidated when it is fetched via {@see CacheInterface::get()}.
      * @return bool whether the value is successfully stored into cache
      */
@@ -79,7 +79,7 @@ interface CacheInterface extends \Psr\SimpleCache\CacheInterface
      *
      * @param array $values the values to be cached, as key-value pairs.
      * @param null|int|\DateInterval $ttl the TTL of this value. If not set, default value is used.
-     * @param Dependency $dependency dependency of the cached values. If the dependency changes,
+     * @param Dependency|null $dependency dependency of the cached values. If the dependency changes,
      * the corresponding values in the cache will be invalidated when it is fetched via {@see CacheInterface::get()}.
      * @return bool
      */
@@ -105,7 +105,7 @@ interface CacheInterface extends \Psr\SimpleCache\CacheInterface
      * @param callable $callable the callable or closure that will be used to generate a value to be cached.
      * In case $callable returns `false`, the value will not be cached.
      * @param null|int|\DateInterval $ttl the TTL of this value. If not set, default value is used.
-     * @param Dependency $dependency dependency of the value. If the dependency changes,
+     * @param Dependency|null $dependency dependency of the value. If the dependency changes,
      * the corresponding value in the cache will be invalidated when it is fetched via {@see get()}.
      * @return mixed result of $callable execution
      */

--- a/src/Dependency/AllDependencies.php
+++ b/src/Dependency/AllDependencies.php
@@ -37,6 +37,7 @@ class AllDependencies extends Dependency
      *
      * @param CacheInterface $cache
      * @return null
+     * @suppress PhanUnusedProtectedMethodParameter
      */
     protected function generateDependencyData(CacheInterface $cache)
     {

--- a/src/Dependency/AnyDependency.php
+++ b/src/Dependency/AnyDependency.php
@@ -37,6 +37,7 @@ class AnyDependency extends Dependency
      *
      * @param CacheInterface $cache
      * @return null
+     * @suppress PhanUnusedProtectedMethodParameter
      */
     protected function generateDependencyData(CacheInterface $cache)
     {

--- a/src/Dependency/CallbackDependency.php
+++ b/src/Dependency/CallbackDependency.php
@@ -19,6 +19,11 @@ class CallbackDependency extends Dependency
         $this->callback = $callback;
     }
 
+    /**
+     * @param CacheInterface $cache
+     * @return mixed
+     * @suppress PhanUnusedProtectedMethodParameter
+     */
     protected function generateDependencyData(CacheInterface $cache)
     {
         $callback = $this->callback;

--- a/src/Dependency/FileDependency.php
+++ b/src/Dependency/FileDependency.php
@@ -23,6 +23,12 @@ final class FileDependency extends Dependency
         $this->fileName = $fileName;
     }
 
+    /**
+     * @param CacheInterface $cache
+     * @return false|int|mixed
+     * @suppress PhanUnusedProtectedMethodParameter
+     * @suppress PhanUnusedProtectedFinalMethodParameter
+     */
     protected function generateDependencyData(CacheInterface $cache)
     {
         clearstatcache(false, $this->fileName);

--- a/src/Dependency/TagDependency.php
+++ b/src/Dependency/TagDependency.php
@@ -39,6 +39,7 @@ final class TagDependency extends Dependency
      * @param CacheInterface $cache the cache component that is currently evaluating this dependency
      * @return mixed the data needed to determine if dependency has been changed.
      * @throws InvalidArgumentException
+     * @suppress PhanTypeInvalidThrowsIsInterface
      */
     protected function generateDependencyData(CacheInterface $cache): array
     {
@@ -88,6 +89,7 @@ final class TagDependency extends Dependency
      * @param string[] $tags
      * @return array the timestamps indexed by the specified tags.
      * @throws InvalidArgumentException
+     * @suppress PhanTypeInvalidThrowsIsInterface
      */
     private function getStoredTagTimestamps(CacheInterface $cache, array $tags): iterable
     {

--- a/src/Dependency/TagDependency.php
+++ b/src/Dependency/TagDependency.php
@@ -112,7 +112,7 @@ final class TagDependency extends Dependency
     {
         $jsonTag = json_encode([__CLASS__, $tag]);
         if ($jsonTag === false) {
-            throw new \Yiisoft\Cache\Exception\InvalidArgumentException('Invalid tag.');
+            throw new \Yiisoft\Cache\Exception\InvalidArgumentException('Invalid tag. ' . json_last_error_msg());
         }
 
         return md5($jsonTag);

--- a/src/NullCache.php
+++ b/src/NullCache.php
@@ -9,6 +9,7 @@ use Yiisoft\Cache\Dependency\Dependency;
  *
  * By replacing it with some other cache component, one can quickly switch from
  * non-caching mode to caching mode.
+ * @phan-file-suppress PhanUnusedPublicFinalMethodParameter
  */
 final class NullCache implements CacheInterface
 {

--- a/tests/ArrayCache/ArrayCacheDecoratorExtraTest.php
+++ b/tests/ArrayCache/ArrayCacheDecoratorExtraTest.php
@@ -2,6 +2,8 @@
 
 namespace Yiisoft\Cache\Tests\ArrayCache;
 
+require_once __DIR__ . '/../MockHelper.php';
+
 use DateInterval;
 use Psr\SimpleCache\CacheInterface;
 use Yiisoft\Cache\ArrayCache;
@@ -10,10 +12,17 @@ use Yiisoft\Cache\Dependency\TagDependency;
 use Yiisoft\Cache\Exception\InvalidArgumentException;
 use Yiisoft\Cache\Exception\SetCacheException;
 use Yiisoft\Cache\Tests\FalseCache;
+use Yiisoft\Cache\Tests\MockHelper;
 use Yiisoft\Cache\Tests\TestCase;
 
 class ArrayCacheDecoratorExtraTest extends TestCase
 {
+
+    protected function tearDown(): void
+    {
+        MockHelper::resetMocks();
+    }
+
     protected function createCacheInstance(): CacheInterface
     {
         return new Cache(new ArrayCache());
@@ -168,6 +177,16 @@ class ArrayCacheDecoratorExtraTest extends TestCase
         $this->assertSame(42, $cache->get($key));
     }
 
+    public function testInvalidKey(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        MockHelper::$mock_json_encode = false;
+        $key = [42];
+        $cache = $this->createCacheInstance();
+        $cache->clear();
+        $cache->set($key, 42);
+    }
+
     public function testWithObjectKeys(): void
     {
         $key = new class {
@@ -253,7 +272,7 @@ class ArrayCacheDecoratorExtraTest extends TestCase
         $this->featuresTest($cache);
     }
 
-    public function featuresProvider()
+    public function featuresProvider(): array
     {
         // [prefix, normalization]
         return [
@@ -264,7 +283,7 @@ class ArrayCacheDecoratorExtraTest extends TestCase
         ];
     }
 
-    private function featuresTest(Cache $cache)
+    private function featuresTest(Cache $cache): void
     {
         $this->prepare($cache);
 

--- a/tests/ArrayCache/ArrayCacheDecoratorExtraTest.php
+++ b/tests/ArrayCache/ArrayCacheDecoratorExtraTest.php
@@ -2,8 +2,6 @@
 
 namespace Yiisoft\Cache\Tests\ArrayCache;
 
-require_once __DIR__ . '/../MockHelper.php';
-
 use DateInterval;
 use Psr\SimpleCache\CacheInterface;
 use Yiisoft\Cache\ArrayCache;

--- a/tests/ArrayCache/ArrayCacheDecoratorExtraTest.php
+++ b/tests/ArrayCache/ArrayCacheDecoratorExtraTest.php
@@ -17,7 +17,6 @@ use Yiisoft\Cache\Tests\TestCase;
 
 class ArrayCacheDecoratorExtraTest extends TestCase
 {
-
     protected function tearDown(): void
     {
         MockHelper::resetMocks();

--- a/tests/ArrayCache/ArrayCacheTest.php
+++ b/tests/ArrayCache/ArrayCacheTest.php
@@ -9,15 +9,14 @@ use Psr\SimpleCache\CacheInterface;
 use Psr\SimpleCache\InvalidArgumentException;
 use ReflectionException;
 use Yiisoft\Cache\ArrayCache;
-use Yiisoft\Cache\Cache;
-use Yiisoft\Cache\MockHelper;
+use Yiisoft\Cache\Tests\MockHelper;
 use Yiisoft\Cache\Tests\TestCase;
 
 class ArrayCacheTest extends TestCase
 {
     protected function tearDown(): void
     {
-        MockHelper::$time = null;
+        MockHelper::resetMocks();
     }
 
     protected function createCacheInstance(): CacheInterface
@@ -30,14 +29,14 @@ class ArrayCacheTest extends TestCase
         $cache = $this->createCacheInstance();
         $cache->clear();
 
-        MockHelper::$time = \time();
+        MockHelper::$mock_time = \time();
         $this->assertTrue($cache->set('expire_test', 'expire_test', 2));
 
-        MockHelper::$time++;
+        MockHelper::$mock_time++;
         $this->assertTrue($cache->has('expire_test'));
         $this->assertSameExceptObject('expire_test', $cache->get('expire_test'));
 
-        MockHelper::$time++;
+        MockHelper::$mock_time++;
         $this->assertFalse($cache->has('expire_test'));
         $this->assertNull($cache->get('expire_test'));
     }
@@ -286,8 +285,8 @@ class ArrayCacheTest extends TestCase
     public function testTtlToExpiration($ttl, $expected): void
     {
         if ($expected === 'calculate_expiration') {
-            MockHelper::$time = \time();
-            $expected = MockHelper::$time + $ttl;
+            MockHelper::$mock_time = \time();
+            $expected = MockHelper::$mock_time + $ttl;
         }
         $cache = new ArrayCache();
         $this->assertSameExceptObject($expected, $this->invokeMethod($cache, 'ttlToExpiration', [$ttl]));

--- a/tests/ArrayCache/ArrayCacheTest.php
+++ b/tests/ArrayCache/ArrayCacheTest.php
@@ -2,8 +2,6 @@
 
 namespace Yiisoft\Cache\Tests\ArrayCache;
 
-require_once __DIR__ . '/../MockHelper.php';
-
 use DateInterval;
 use Psr\SimpleCache\CacheInterface;
 use Psr\SimpleCache\InvalidArgumentException;

--- a/tests/Dependency/DependencyTest.php
+++ b/tests/Dependency/DependencyTest.php
@@ -36,6 +36,18 @@ class DependencyTest extends DependencyTestCase
         $this->assertSameExceptObject(40, strlen($result));
     }
 
+    public function testIsChangedReusable(): void
+    {
+        /* @var $dependency Dependency */
+        $dependency = $this->getMockForAbstractClass(Dependency::class);
+        $dependency->markAsReusable();
+        $this->assertDependencyNotChanged($dependency);
+
+        $this->setInaccessibleProperty($dependency, 'data', 'changed');
+
+        $this->assertDependencyChanged($dependency);
+    }
+
     public function testIsChanged(): void
     {
         /* @var $dependency Dependency */

--- a/tests/Dependency/TagDependencyTest.php
+++ b/tests/Dependency/TagDependencyTest.php
@@ -2,13 +2,22 @@
 
 namespace Yiisoft\Cache\Tests\Dependency;
 
+require_once __DIR__ . '/../MockHelper.php';
+
 use Yiisoft\Cache\ArrayCache;
 use Yiisoft\Cache\Cache;
 use Yiisoft\Cache\CacheInterface;
 use Yiisoft\Cache\Dependency\TagDependency;
+use Yiisoft\Cache\Exception\InvalidArgumentException;
+use Yiisoft\Cache\Tests\MockHelper;
 
 class TagDependencyTest extends DependencyTestCase
 {
+    protected function tearDown(): void
+    {
+        MockHelper::resetMocks();
+    }
+
     protected function createCache(): CacheInterface
     {
         // isChanged of TagDependency needs cache access.
@@ -35,12 +44,21 @@ class TagDependencyTest extends DependencyTestCase
         $this->assertNull($cache->get('item_42_total'));
     }
 
-    public function testEmptyTags()
+    public function testEmptyTags(): void
     {
         $cache = $this->getCache();
         $dependency = new TagDependency([]);
         $cache->set('item_42_price', 13, null, $dependency);
         $this->assertSame(13, $cache->get('item_42_price'));
         $this->assertSame([], $this->getInaccessibleProperty($dependency, 'data'));
+    }
+
+    public function testInvalidTag(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        MockHelper::$mock_json_encode = false;
+        $cache = $this->getCache();
+        $dependency = new TagDependency(['test']);
+        $dependency->isChanged($cache);
     }
 }

--- a/tests/Dependency/TagDependencyTest.php
+++ b/tests/Dependency/TagDependencyTest.php
@@ -2,8 +2,6 @@
 
 namespace Yiisoft\Cache\Tests\Dependency;
 
-require_once __DIR__ . '/../MockHelper.php';
-
 use Yiisoft\Cache\ArrayCache;
 use Yiisoft\Cache\Cache;
 use Yiisoft\Cache\CacheInterface;

--- a/tests/MockHelper.php
+++ b/tests/MockHelper.php
@@ -1,15 +1,6 @@
 <?php
 
-namespace Yiisoft\Cache;
-
-/**
- * Mock for the time() function
- * @return int
- */
-function time(): int
-{
-    return MockHelper::$time ?: \time();
-}
+namespace Yiisoft\Cache\Tests;
 
 class MockHelper
 {
@@ -17,5 +8,51 @@ class MockHelper
      * @var int virtual time to be returned by mocked time() function.
      * null means normal time() behavior.
      */
-    public static $time;
+    public static $mock_time;
+    /**
+     * @var string|false value to be returned by mocked json_encode() function.
+     * null means normal json_encode() behavior.
+     */
+    public static $mock_json_encode;
+
+    public static function resetMocks(): void
+    {
+        static::$mock_time = null;
+        static::$mock_json_encode = null;
+    }
+}
+
+namespace Yiisoft\Cache;
+
+use Yiisoft\Cache\Tests\MockHelper;
+
+/**
+ * Mock for the time() function
+ * @return int
+ */
+function time(): int
+{
+    return MockHelper::$mock_time ?? \time();
+}
+
+/**
+ * Mock for the json_encode() function
+ * @return string|false
+ */
+function json_encode($value, $options = 0, $depth = 512)
+{
+    return MockHelper::$mock_json_encode ?? \json_encode($value, $options, $depth);
+}
+
+namespace Yiisoft\Cache\Dependency;
+
+use Yiisoft\Cache\Tests\MockHelper;
+
+/**
+ * Mock for the json_encode() function
+ * @return string|false
+ */
+function json_encode($value, $options = 0, $depth = 512)
+{
+    return MockHelper::$mock_json_encode ?? \json_encode($value, $options, $depth);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 

Fixed issues reported by `phan/phan`. Added tests.

Phan report:

```
src/ArrayCache.php:70 PhanPossiblyNullTypeArgument Argument 1 ($key) is mixed|null but \Yiisoft\Cache\ArrayCache::get() takes string (null is incompatible) defined at src/ArrayCache.php:22
src/ArrayCache.php:91 PhanPossiblyNullTypeArgument Argument 1 ($key) is mixed|null but \Yiisoft\Cache\ArrayCache::delete() takes string (null is incompatible) defined at src/ArrayCache.php:51
src/ArrayCache.php:142 PhanPossiblyFalseTypeReturn Returning type false|int but normalizeTtl() is declared to return int|null (false is incompatible)
src/Cache.php:59 PhanUnextractableAnnotationElementName Saw possibly unextractable annotation for a fragment of comment '* @param \Psr\SimpleCache\CacheInterface cache handler.': after \Psr\SimpleCache\CacheInterface, did not see an element name (will guess based on comment order)
src/Cache.php:63 PhanPossiblyNullTypeMismatchProperty Assigning ?\Psr\SimpleCache\CacheInterface to property but \Yiisoft\Cache\Cache->handler is \Psr\SimpleCache\CacheInterface (null is incompatible)
src/Cache.php:83 PhanPossiblyFalseTypeArgumentInternal Argument 1 ($str) is false|string but \md5() takes string (false is incompatible)
src/Cache.php:118 PhanParamSignatureMismatch Declaration of function getMultiple(string[] $keys, mixed $default = null) : iterable should be compatible with function getMultiple(iterable $keys, mixed $default = null) : iterable defined in vendor/psr/simple-cache/src/CacheInterface.php:67
src/Cache.php:118 PhanTypeInvalidThrowsIsInterface @throws annotation of getMultiple has suspicious interface type \Psr\SimpleCache\InvalidArgumentException for an @throws annotation, expected class (PHP allows interfaces to be caught, so this might be intentional) (Did you mean class \InvalidArgumentException or class \Yiisoft\Cache\Exception\InvalidArgumentException)
src/Cache.php:137 PhanTypeMismatchDeclaredParamNullable Doc-block of $dependency in set is phpdoc param type \Yiisoft\Cache\Dependency\Dependency which is not a permitted replacement of the nullable param type ?\Yiisoft\Cache\Dependency\Dependency declared in the signature ('?T' should be documented as 'T|null' or '?T')
src/Cache.php:142 PhanTypeInvalidThrowsIsInterface @throws annotation of set has suspicious interface type \Psr\SimpleCache\InvalidArgumentException for an @throws annotation, expected class (PHP allows interfaces to be caught, so this might be intentional) (Did you mean class \InvalidArgumentException or class \Yiisoft\Cache\Exception\InvalidArgumentException)
src/Cache.php:159 PhanTypeMismatchDeclaredParamNullable Doc-block of $dependency in setMultiple is phpdoc param type \Yiisoft\Cache\Dependency\Dependency which is not a permitted replacement of the nullable param type ?\Yiisoft\Cache\Dependency\Dependency declared in the signature ('?T' should be documented as 'T|null' or '?T')
src/Cache.php:164 PhanTypeInvalidThrowsIsInterface @throws annotation of setMultiple has suspicious interface type \Psr\SimpleCache\InvalidArgumentException for an @throws annotation, expected class (PHP allows interfaces to be caught, so this might be intentional) (Did you mean class \InvalidArgumentException or class \Yiisoft\Cache\Exception\InvalidArgumentException)
src/Cache.php:183 PhanTypeMismatchDeclaredParamNullable Doc-block of $dependency in addMultiple is phpdoc param type \Yiisoft\Cache\Dependency\Dependency which is not a permitted replacement of the nullable param type ?\Yiisoft\Cache\Dependency\Dependency declared in the signature ('?T' should be documented as 'T|null' or '?T')
src/Cache.php:188 PhanTypeInvalidThrowsIsInterface @throws annotation of addMultiple has suspicious interface type \Psr\SimpleCache\InvalidArgumentException for an @throws annotation, expected class (PHP allows interfaces to be caught, so this might be intentional) (Did you mean class \InvalidArgumentException or class \Yiisoft\Cache\Exception\InvalidArgumentException)
src/Cache.php:217 PhanTypeMismatchDeclaredParamNullable Doc-block of $dependency in add is phpdoc param type \Yiisoft\Cache\Dependency\Dependency which is not a permitted replacement of the nullable param type ?\Yiisoft\Cache\Dependency\Dependency declared in the signature ('?T' should be documented as 'T|null' or '?T')
src/Cache.php:222 PhanTypeInvalidThrowsIsInterface @throws annotation of add has suspicious interface type \Psr\SimpleCache\InvalidArgumentException for an @throws annotation, expected class (PHP allows interfaces to be caught, so this might be intentional) (Did you mean class \InvalidArgumentException or class \Yiisoft\Cache\Exception\InvalidArgumentException)
src/Cache.php:244 PhanTypeInvalidThrowsIsInterface @throws annotation of delete has suspicious interface type \Psr\SimpleCache\InvalidArgumentException for an @throws annotation, expected class (PHP allows interfaces to be caught, so this might be intentional) (Did you mean class \InvalidArgumentException or class \Yiisoft\Cache\Exception\InvalidArgumentException)
src/Cache.php:282 PhanTypeMismatchDeclaredParamNullable Doc-block of $dependency in getOrSet is phpdoc param type \Yiisoft\Cache\Dependency\Dependency which is not a permitted replacement of the nullable param type ?\Yiisoft\Cache\Dependency\Dependency declared in the signature ('?T' should be documented as 'T|null' or '?T')
src/Cache.php:288 PhanTypeInvalidThrowsIsInterface @throws annotation of getOrSet has suspicious interface type \Psr\SimpleCache\InvalidArgumentException for an @throws annotation, expected class (PHP allows interfaces to be caught, so this might be intentional) (Did you mean class \InvalidArgumentException or class \Yiisoft\Cache\Exception\InvalidArgumentException)
src/Cache.php:356 PhanPossiblyFalseTypeReturn Returning type false|int but normalizeTtl() is declared to return int|null (false is incompatible)
src/CacheInterface.php:44 PhanTypeMismatchDeclaredParamNullable Doc-block of $dependency in set is phpdoc param type \Yiisoft\Cache\Dependency\Dependency which is not a permitted replacement of the nullable param type ?\Yiisoft\Cache\Dependency\Dependency declared in the signature ('?T' should be documented as 'T|null' or '?T')
src/CacheInterface.php:57 PhanTypeMismatchDeclaredParamNullable Doc-block of $dependency in setMultiple is phpdoc param type \Yiisoft\Cache\Dependency\Dependency which is not a permitted replacement of the nullable param type ?\Yiisoft\Cache\Dependency\Dependency declared in the signature ('?T' should be documented as 'T|null' or '?T')
src/CacheInterface.php:61 PhanParamSignatureMismatch Declaration of function setMultiple(array $values, \DateInterval|int|null $ttl = null, ?\Yiisoft\Cache\Dependency\Dependency $dependency = null) : bool should be compatible with function setMultiple(iterable $values, \DateInterval|int|null $ttl = null) : bool defined in vendor/psr/simple-cache/src/CacheInterface.php:83
src/CacheInterface.php:70 PhanTypeMismatchDeclaredParamNullable Doc-block of $dependency in add is phpdoc param type \Yiisoft\Cache\Dependency\Dependency which is not a permitted replacement of the nullable param type ?\Yiisoft\Cache\Dependency\Dependency declared in the signature ('?T' should be documented as 'T|null' or '?T')
src/CacheInterface.php:82 PhanTypeMismatchDeclaredParamNullable Doc-block of $dependency in addMultiple is phpdoc param type \Yiisoft\Cache\Dependency\Dependency which is not a permitted replacement of the nullable param type ?\Yiisoft\Cache\Dependency\Dependency declared in the signature ('?T' should be documented as 'T|null' or '?T')
src/CacheInterface.php:108 PhanTypeMismatchDeclaredParamNullable Doc-block of $dependency in getOrSet is phpdoc param type \Yiisoft\Cache\Dependency\Dependency which is not a permitted replacement of the nullable param type ?\Yiisoft\Cache\Dependency\Dependency declared in the signature ('?T' should be documented as 'T|null' or '?T')
src/Dependency/AllDependencies.php:41 PhanUnusedProtectedMethodParameter Parameter $cache is never used
src/Dependency/AnyDependency.php:41 PhanUnusedProtectedMethodParameter Parameter $cache is never used
src/Dependency/CallbackDependency.php:22 PhanUnusedProtectedMethodParameter Parameter $cache is never used
src/Dependency/FileDependency.php:26 PhanUnusedProtectedFinalMethodParameter Parameter $cache is never used
src/Dependency/TagDependency.php:40 PhanTypeMismatchDeclaredReturn Doc-block of generateDependencyData contains declared return type mixed which is incompatible with the return type array declared in the signature
src/Dependency/TagDependency.php:43 PhanTypeInvalidThrowsIsInterface @throws annotation of generateDependencyData has suspicious interface type \Psr\SimpleCache\InvalidArgumentException for an @throws annotation, expected class (PHP allows interfaces to be caught, so this might be intentional) (Did you mean class \InvalidArgumentException or class \Yiisoft\Cache\Exception\InvalidArgumentException)
src/Dependency/TagDependency.php:92 PhanTypeInvalidThrowsIsInterface @throws annotation of getStoredTagTimestamps has suspicious interface type \Psr\SimpleCache\InvalidArgumentException for an @throws annotation, expected class (PHP allows interfaces to be caught, so this might be intentional) (Did you mean class \InvalidArgumentException or class \Yiisoft\Cache\Exception\InvalidArgumentException)
src/Dependency/TagDependency.php:100 PhanTypeMismatchReturn Returning type iterable but getStoredTagTimestamps() is declared to return array
src/Dependency/TagDependency.php:111 PhanPossiblyFalseTypeArgumentInternal Argument 1 ($str) is false|string but \md5() takes string (false is incompatible)
src/Dependency/TagDependency.php:123 PhanPossiblyNullTypeArgument Argument 1 ($tag) is mixed|null but \Yiisoft\Cache\Dependency\TagDependency::buildCacheKey() takes string (null is incompatible) defined at src/Dependency/TagDependency.php:109
src/Dependency/TagDependency.php:147 PhanPartialTypeMismatchReturn Returning type array|iterable but storeTimestampsForNewTags() is declared to return array (iterable is incompatible)
src/NullCache.php:15 PhanUnusedPublicFinalMethodParameter Parameter $dependency is never used
src/NullCache.php:15 PhanUnusedPublicFinalMethodParameter Parameter $key is never used
src/NullCache.php:15 PhanUnusedPublicFinalMethodParameter Parameter $ttl is never used
src/NullCache.php:15 PhanUnusedPublicFinalMethodParameter Parameter $value is never used
src/NullCache.php:20 PhanUnusedPublicFinalMethodParameter Parameter $keys is never used
src/NullCache.php:25 PhanUnusedPublicFinalMethodParameter Parameter $dependency is never used
src/NullCache.php:25 PhanUnusedPublicFinalMethodParameter Parameter $key is never used
src/NullCache.php:25 PhanUnusedPublicFinalMethodParameter Parameter $ttl is never used
src/NullCache.php:25 PhanUnusedPublicFinalMethodParameter Parameter $value is never used
src/NullCache.php:30 PhanUnusedPublicFinalMethodParameter Parameter $key is never used
src/NullCache.php:40 PhanUnusedPublicFinalMethodParameter Parameter $dependency is never used
src/NullCache.php:40 PhanUnusedPublicFinalMethodParameter Parameter $ttl is never used
src/NullCache.php:40 PhanUnusedPublicFinalMethodParameter Parameter $values is never used
src/NullCache.php:45 PhanUnusedPublicFinalMethodParameter Parameter $dependency is never used
src/NullCache.php:45 PhanUnusedPublicFinalMethodParameter Parameter $ttl is never used
src/NullCache.php:45 PhanUnusedPublicFinalMethodParameter Parameter $values is never used
src/NullCache.php:50 PhanUnusedPublicFinalMethodParameter Parameter $dependency is never used
src/NullCache.php:50 PhanUnusedPublicFinalMethodParameter Parameter $key is never used
src/NullCache.php:50 PhanUnusedPublicFinalMethodParameter Parameter $ttl is never used
src/NullCache.php:55 PhanUnusedPublicFinalMethodParameter Parameter $key is never used
src/NullCache.php:65 PhanUnusedPublicFinalMethodParameter Parameter $key is never used
src/NullCache.php:80 PhanUnusedPublicFinalMethodParameter Parameter $keyPrefix is never used

```

Phan config:

```php
<?php

use Phan\Issue;

/**
 * This configuration file was automatically generated by 'phan --init --init-level=1'
 *
 * TODOs (added by 'phan --init'):
 *
 * - Go through this file and verify that there are no missing/unnecessary files/directories.
 *   (E.g. this only includes direct composer dependencies - You may have to manually add indirect composer dependencies to 'directory_list')
 * - Look at 'plugins' and add or remove plugins if appropriate (see https://github.com/phan/phan/tree/master/.phan/plugins#plugins)
 * - Add global suppressions for pre-existing issues to suppress_issue_types (https://github.com/phan/phan/wiki/Tutorial-for-Analyzing-a-Large-Sloppy-Code-Base)
 *
 * This configuration will be read and overlaid on top of the
 * default configuration. Command line arguments will be applied
 * after this file is read.
 *
 * @see src/Phan/Config.php
 * See Config for all configurable options.
 *
 * A Note About Paths
 * ==================
 *
 * Files referenced from this file should be defined as
 *
 * ```
 *   Config::projectPath('relative_path/to/file')
 * ```
 *
 * where the relative path is relative to the root of the
 * project which is defined as either the working directory
 * of the phan executable or a path passed in via the CLI
 * '-d' flag.
 */
return [

    // Supported values: `'5.6'`, `'7.0'`, `'7.1'`, `'7.2'`, `'7.3'`, `'7.4'`, `null`.
    // If this is set to `null`,
    // then Phan assumes the PHP version which is closest to the minor version
    // of the php executable used to execute Phan.
    //
    // Note that the **only** effect of choosing `'5.6'` is to infer that functions removed in php 7.0 exist.
    // (See `backward_compatibility_checks` for additional options)
    // Automatically inferred from composer.json requirement for "php" of ">=7.1.0"
    'target_php_version' => '7.1',

    // If enabled, missing properties will be created when
    // they are first seen. If false, we'll report an
    // error message if there is an attempt to write
    // to a class property that wasn't explicitly
    // defined.
    'allow_missing_properties' => false,

    // If enabled, null can be cast to any type and any
    // type can be cast to null. Setting this to true
    // will cut down on false positives.
    'null_casts_as_any_type' => false,

    // If enabled, allow null to be cast as any array-like type.
    //
    // This is an incremental step in migrating away from `null_casts_as_any_type`.
    // If `null_casts_as_any_type` is true, this has no effect.
    'null_casts_as_array' => false,

    // If enabled, allow any array-like type to be cast to null.
    // This is an incremental step in migrating away from `null_casts_as_any_type`.
    // If `null_casts_as_any_type` is true, this has no effect.
    'array_casts_as_null' => false,

    // If enabled, scalars (int, float, bool, string, null)
    // are treated as if they can cast to each other.
    // This does not affect checks of array keys. See `scalar_array_key_cast`.
    'scalar_implicit_cast' => false,

    // If enabled, any scalar array keys (int, string)
    // are treated as if they can cast to each other.
    // E.g. `array<int,stdClass>` can cast to `array<string,stdClass>` and vice versa.
    // Normally, a scalar type such as int could only cast to/from int and mixed.
    'scalar_array_key_cast' => false,

    // If this has entries, scalars (int, float, bool, string, null)
    // are allowed to perform the casts listed.
    //
    // E.g. `['int' => ['float', 'string'], 'float' => ['int'], 'string' => ['int'], 'null' => ['string']]`
    // allows casting null to a string, but not vice versa.
    // (subset of `scalar_implicit_cast`)
    'scalar_implicit_partial' => [],

    // If enabled, Phan will warn if **any** type in a method invocation's object
    // is definitely not an object,
    // or if **any** type in an invoked expression is not a callable.
    // Setting this to true will introduce numerous false positives
    // (and reveal some bugs).
    'strict_method_checking' => true,

    // If enabled, Phan will warn if **any** type of the object expression for a property access
    // does not contain that property.
    'strict_object_checking' => true,

    // If enabled, Phan will warn if **any** type in the argument's union type
    // cannot be cast to a type in the parameter's expected union type.
    // Setting this to true will introduce numerous false positives
    // (and reveal some bugs).
    'strict_param_checking' => true,

    // If enabled, Phan will warn if **any** type in a property assignment's union type
    // cannot be cast to a type in the property's declared union type.
    // Setting this to true will introduce numerous false positives
    // (and reveal some bugs).
    'strict_property_checking' => true,

    // If enabled, Phan will warn if **any** type in a returned value's union type
    // cannot be cast to the declared return type.
    // Setting this to true will introduce numerous false positives
    // (and reveal some bugs).
    'strict_return_checking' => true,

    // If true, seemingly undeclared variables in the global
    // scope will be ignored.
    //
    // This is useful for projects with complicated cross-file
    // globals that you have no hope of fixing.
    'ignore_undeclared_variables_in_global_scope' => false,

    // Set this to false to emit `PhanUndeclaredFunction` issues for internal functions that Phan has signatures for,
    // but aren't available in the codebase, or the internal functions used to run Phan
    // (may lead to false positives if an extension isn't loaded)
    //
    // If this is true(default), then Phan will not warn.
    'ignore_undeclared_functions_with_known_signatures' => false,

    // Backwards Compatibility Checking. This is slow
    // and expensive, but you should consider running
    // it before upgrading your version of PHP to a
    // new version that has backward compatibility
    // breaks.
    //
    // If you are migrating from PHP 5 to PHP 7,
    // you should also look into using
    // [php7cc (no longer maintained)](https://github.com/sstalle/php7cc)
    // and [php7mar](https://github.com/Alexia/php7mar),
    // which have different backwards compatibility checks.
    'backward_compatibility_checks' => false,

    // If true, check to make sure the return type declared
    // in the doc-block (if any) matches the return type
    // declared in the method signature.
    'check_docblock_signature_return_type_match' => true,

    // If true, make narrowed types from phpdoc params override
    // the real types from the signature, when real types exist.
    // (E.g. allows specifying desired lists of subclasses,
    //  or to indicate a preference for non-nullable types over nullable types)
    //
    // Affects analysis of the body of the method and the param types passed in by callers.
    //
    // (*Requires `check_docblock_signature_param_type_match` to be true*)
    'prefer_narrowed_phpdoc_param_type' => true,

    // (*Requires `check_docblock_signature_return_type_match` to be true*)
    //
    // If true, make narrowed types from phpdoc returns override
    // the real types from the signature, when real types exist.
    //
    // (E.g. allows specifying desired lists of subclasses,
    // or to indicate a preference for non-nullable types over nullable types)
    //
    // This setting affects the analysis of return statements in the body of the method and the return types passed in by callers.
    'prefer_narrowed_phpdoc_return_type' => true,

    // If enabled, check all methods that override a
    // parent method to make sure its signature is
    // compatible with the parent's.
    //
    // This check can add quite a bit of time to the analysis.
    //
    // This will also check if final methods are overridden, etc.
    'analyze_signature_compatibility' => true,

    // This setting maps case-insensitive strings to union types.
    //
    // This is useful if a project uses phpdoc that differs from the phpdoc2 standard.
    //
    // If the corresponding value is the empty string,
    // then Phan will ignore that union type (E.g. can ignore 'the' in `@return the value`)
    //
    // If the corresponding value is not empty,
    // then Phan will act as though it saw the corresponding UnionTypes(s)
    // when the keys show up in a UnionType of `@param`, `@return`, `@var`, `@property`, etc.
    //
    // This matches the **entire string**, not parts of the string.
    // (E.g. `@return the|null` will still look for a class with the name `the`, but `@return the` will be ignored with the below setting)
    //
    // (These are not aliases, this setting is ignored outside of doc comments).
    // (Phan does not check if classes with these names exist)
    //
    // Example setting: `['unknown' => '', 'number' => 'int|float', 'char' => 'string', 'long' => 'int', 'the' => '']`
    'phpdoc_type_mapping' => [],

    // Set to true in order to attempt to detect dead
    // (unreferenced) code. Keep in mind that the
    // results will only be a guess given that classes,
    // properties, constants and methods can be referenced
    // as variables (like `$class->$property` or
    // `$class->$method()`) in ways that we're unable
    // to make sense of.
    'dead_code_detection' => false,

    // Set to true in order to attempt to detect unused variables.
    // `dead_code_detection` will also enable unused variable detection.
    //
    // This has a few known false positives, e.g. for loops or branches.
    'unused_variable_detection' => true,

    // Set to true in order to attempt to detect redundant and impossible conditions.
    //
    // This has some false positives involving loops,
    // variables set in branches of loops, and global variables.
    'redundant_condition_detection' => true,

    // If enabled, Phan will act as though it's certain of real return types of a subset of internal functions,
    // even if those return types aren't available in reflection (real types were taken from php 7.3 or 8.0-dev, depending on target_php_version).
    //
    // Note that with php 7 and earlier, php would return null or false for many internal functions if the argument types or counts were incorrect.
    // As a result, enabling this setting with target_php_version 8.0 may result in false positives for `--redundant-condition-detection` when codebases also support php 7.x.
    'assume_real_types_for_internal_functions' => true,

    // If true, this runs a quick version of checks that takes less
    // time at the cost of not running as thorough
    // of an analysis. You should consider setting this
    // to true only when you wish you had more **undiagnosed** issues
    // to fix in your code base.
    //
    // In quick-mode the scanner doesn't rescan a function
    // or a method's code block every time a call is seen.
    // This means that the problem here won't be detected:
    //
    // ```php
    // <?php
    // function test($arg):int {
    //     return $arg;
    // }
    // test("abc");
    // ```
    //
    // This would normally generate:
    //
    // ```
    // test.php:3 PhanTypeMismatchReturn Returning type string but test() is declared to return int
    // ```
    //
    // The initial scan of the function's code block has no
    // type information for `$arg`. It isn't until we see
    // the call and rescan `test()`'s code block that we can
    // detect that it is actually returning the passed in
    // `string` instead of an `int` as declared.
    'quick_mode' => false,

    // Enable or disable support for generic templated
    // class types.
    'generic_types_enabled' => true,

    // Override to hardcode existence and types of (non-builtin) globals in the global scope.
    // Class names should be prefixed with `\`.
    //
    // (E.g. `['_FOO' => '\FooClass', 'page' => '\PageClass', 'userId' => 'int']`)
    'globals_type_map' => [],

    // The minimum severity level to report on. This can be
    // set to `Issue::SEVERITY_LOW`, `Issue::SEVERITY_NORMAL` or
    // `Issue::SEVERITY_CRITICAL`. Setting it to only
    // critical issues is a good place to start on a big
    // sloppy mature code base.
    'minimum_severity' => Issue::SEVERITY_LOW,

    // Add any issue types (such as `'PhanUndeclaredMethod'`)
    // to this black-list to inhibit them from being reported.
    'suppress_issue_types' => [],

    // A regular expression to match files to be excluded
    // from parsing and analysis and will not be read at all.
    //
    // This is useful for excluding groups of test or example
    // directories/files, unanalyzable files, or files that
    // can't be removed for whatever reason.
    // (e.g. `'@Test\.php$@'`, or `'@vendor/.*/(tests|Tests)/@'`)
    'exclude_file_regex' => '@^vendor/.*/(tests?|Tests?)/@',

    // A file list that defines files that will be excluded
    // from parsing and analysis and will not be read at all.
    //
    // This is useful for excluding hopelessly unanalyzable
    // files that can't be removed for whatever reason.
    'exclude_file_list' => [],

    // A directory list that defines files that will be excluded
    // from static analysis, but whose class and method
    // information should be included.
    //
    // Generally, you'll want to include the directories for
    // third-party code (such as "vendor/") in this list.
    //
    // n.b.: If you'd like to parse but not analyze 3rd
    //       party code, directories containing that code
    //       should be added to the `directory_list` as well as
    //       to `exclude_analysis_directory_list`.
    'exclude_analysis_directory_list' => [
        'vendor/',
    ],

    // Enable this to enable checks of require/include statements referring to valid paths.
    'enable_include_path_checks' => true,

    // The number of processes to fork off during the analysis
    // phase.
    'processes' => 1,

    // List of case-insensitive file extensions supported by Phan.
    // (e.g. `['php', 'html', 'htm']`)
    'analyzed_file_extensions' => [
        'php',
    ],

    // You can put paths to stubs of internal extensions in this config option.
    // If the corresponding extension is **not** loaded, then Phan will use the stubs instead.
    // Phan will continue using its detailed type annotations,
    // but load the constants, classes, functions, and classes (and their Reflection types)
    // from these stub files (doubling as valid php files).
    // Use a different extension from php to avoid accidentally loading these.
    // The `tools/make_stubs` script can be used to generate your own stubs (compatible with php 7.0+ right now)
    //
    // (e.g. `['xdebug' => '.phan/internal_stubs/xdebug.phan_php']`)
    'autoload_internal_extension_signatures' => [],

    // A list of plugin files to execute.
    //
    // Plugins which are bundled with Phan can be added here by providing their name (e.g. `'AlwaysReturnPlugin'`)
    //
    // Documentation about available bundled plugins can be found [here](https://github.com/phan/phan/tree/master/.phan/plugins).
    //
    // Alternately, you can pass in the full path to a PHP file with the plugin's implementation (e.g. `'vendor/phan/phan/.phan/plugins/AlwaysReturnPlugin.php'`)
    'plugins' => [
        'AlwaysReturnPlugin',
        'DollarDollarPlugin',
        'DuplicateArrayKeyPlugin',
        'DuplicateExpressionPlugin',
        'PregRegexCheckerPlugin',
        'PrintfCheckerPlugin',
        'SleepCheckerPlugin',
        'UnreachableCodePlugin',
        'UseReturnValuePlugin',
        'EmptyStatementListPlugin',
        'StrictComparisonPlugin',
        'LoopVariableReusePlugin',
    ],

    // A list of directories that should be parsed for class and
    // method information. After excluding the directories
    // defined in `exclude_analysis_directory_list`, the remaining
    // files will be statically analyzed for errors.
    //
    // Thus, both first-party and third-party code being used by
    // your application should be included in this list.
    'directory_list' => [
        'src',
        'vendor/phpunit/phpunit/src',
        'vendor/psr/simple-cache/src',
    ],

    // A list of individual files to include in analysis
    // with a path relative to the root directory of the
    // project.
    'file_list' => [],
];

```