### PR TITLE
Move prefix to PSR-16 decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ There are two ways to get cache instance. If you need PSR-16 instance, you can s
 $arrayCache = new \Yiisoft\Cache\ArrayCache();
 ```
 
+In order to set a global key prefix:
+
+```php
+$arrayCacheWithPrefix = new \Yiisoft\Cache\PrefixedCache(new \Yiisoft\Cache\ArrayCache(), 'myapp_');
+```
+
 If you need a simpler yet more powerful way to cache values based on recomputation callbacks use `getOrSet()` and `remove()`, additional features such as invalidation dependencies and
 "Probably early expiration" stampede prevention, you should wrap PSR-16 cache instance with `\Yiisoft\Cache\Cache`:
 
@@ -52,12 +58,6 @@ Set a default TTL:
 
 ```php
 $cache = new \Yiisoft\Cache\Cache($arrayCache, 60 * 60); // 1 hour
-```
-
-Set a key prefix:
-
-```php
-$cache = new \Yiisoft\Cache\Cache($arrayCache, null, 'myapp');
 ```
 
 ## General usage

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -43,7 +43,8 @@ final class Cache implements CacheInterface
     private CacheItems $items;
 
     /**
-     * @var int|null
+     * @var int|null The default TTL for a cache entry. null meaning infinity, negative or zero results in the
+     * cache key deletion. This value is used by {@see getOrSet()}, if the duration is not explicitly given.
      */
     private ?int $defaultTtl;
 

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -43,38 +43,26 @@ final class Cache implements CacheInterface
     private CacheItems $items;
 
     /**
-     * @var int|null The default TTL for a cache entry. null meaning infinity, negative or zero results in the
-     * cache key deletion. This value is used by {@see getOrSet()}, if the duration is not explicitly given.
+     * @var int|null
      */
     private ?int $defaultTtl;
-
-    /**
-     * @var string The string prefixed to every cache key so that it is unique globally in the whole cache storage.
-     * It is recommended that you set a unique cache key prefix for each application if the same cache
-     * storage is being used by different applications.
-     */
-    private string $keyPrefix;
 
     /**
      * @param \Psr\SimpleCache\CacheInterface $handler The actual cache handler.
      * @param DateInterval|int|null $defaultTtl The default TTL for a cache entry.
      * null meaning infinity, negative orzero results in the cache key deletion.
      * This value is used by {@see getOrSet()}, if the duration is not explicitly given.
-     * @param string $keyPrefix The string prefixed to every cache key so that it is unique globally
-     * in the whole cache storage. It is recommended that you set a unique cache key prefix for each
-     * application if the same cache storage is being used by different applications.
      */
-    public function __construct(\Psr\SimpleCache\CacheInterface $handler, $defaultTtl = null, string $keyPrefix = '')
+    public function __construct(\Psr\SimpleCache\CacheInterface $handler, $defaultTtl = null)
     {
         $this->handler = $handler;
         $this->items = new CacheItems();
         $this->defaultTtl = $this->normalizeTtl($defaultTtl);
-        $this->keyPrefix = $keyPrefix;
     }
 
     public function getOrSet($key, callable $callable, $ttl = null, Dependency $dependency = null, float $beta = 1.0)
     {
-        $key = $this->buildKey($key);
+        $key = $this->normalizeKey($key);
         $value = $this->getValue($key, $beta);
 
         return $value ?? $this->setAndGet($key, $callable, $ttl, $dependency);
@@ -82,7 +70,7 @@ final class Cache implements CacheInterface
 
     public function remove($key): void
     {
-        $key = $this->buildKey($key);
+        $key = $this->normalizeKey($key);
 
         if (!$this->handler->delete($key)) {
             throw new RemoveCacheException($key);
@@ -151,18 +139,6 @@ final class Cache implements CacheInterface
 
         $this->items->set($item);
         return $value;
-    }
-
-    /**
-     * Builds a normalized cache key from a given key by appending key prefix.
-     *
-     * @param mixed $key The key to be normalized.
-     *
-     * @return string The generated cache key.
-     */
-    private function buildKey($key): string
-    {
-        return $this->keyPrefix . $this->normalizeKey($key);
     }
 
     /**

--- a/src/PrefixedCache.php
+++ b/src/PrefixedCache.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Cache;
 
-use \Psr\SimpleCache\CacheInterface;
+use Psr\SimpleCache\CacheInterface;
 
 /**
  * PrefixedCache decorates any PSR-16 cache to add global prefix. It is added to every cache key so that it is unique
@@ -65,7 +65,7 @@ final class PrefixedCache implements CacheInterface
     {
         $prefixedValues = [];
         foreach ($values as $key => $value) {
-            $prefixedValues[$this->prefix .$key] = $value;
+            $prefixedValues[$this->prefix . $key] = $value;
         }
         return $this->cache->setMultiple($prefixedValues, $ttl);
     }

--- a/src/PrefixedCache.php
+++ b/src/PrefixedCache.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Cache;
+
+use \Psr\SimpleCache\CacheInterface;
+
+/**
+ * PrefixedCache decorates any PSR-16 cache to add global prefix. It is added to every cache key so that it is unique
+ * globally in the whole cache storage. It is recommended that you set a unique cache key prefix for each application
+ * if the same cache storage is being used by different applications.
+ *
+ * ```php
+ * $cache = new PrefixedCache(new ArrayCache(), 'my_app_');
+ * $cache->set('answer', 42); // Will set 42 to my_app_answer key.
+ * ```
+ */
+final class PrefixedCache implements CacheInterface
+{
+    private CacheInterface $cache;
+    private string $prefix;
+
+    /**
+     * @param CacheInterface $cache PSR-16 cache to add prefix to.
+     * @param string $prefix Prefix to use for all cache keys.
+     */
+    public function __construct(CacheInterface $cache, string $prefix)
+    {
+        $this->cache = $cache;
+        $this->prefix = $prefix;
+    }
+
+    public function get($key, $default = null)
+    {
+        return $this->cache->get($this->prefix . $key, $default);
+    }
+
+    public function set($key, $value, $ttl = null)
+    {
+        return $this->cache->set($this->prefix . $key, $value, $ttl);
+    }
+
+    public function delete($key)
+    {
+        return $this->cache->delete($this->prefix . $key);
+    }
+
+    public function clear()
+    {
+        return $this->cache->clear();
+    }
+
+    public function getMultiple($keys, $default = null)
+    {
+        $prefixedKeys = [];
+        foreach ($keys as $key) {
+            $prefixedKeys[] = $this->prefix . $key;
+        }
+
+        return $this->cache->getMultiple($prefixedKeys, $default);
+    }
+
+    public function setMultiple($values, $ttl = null)
+    {
+        $prefixedValues = [];
+        foreach ($values as $key => $value) {
+            $prefixedValues[$this->prefix .$key] = $value;
+        }
+        return $this->cache->setMultiple($prefixedValues, $ttl);
+    }
+
+    public function deleteMultiple($keys)
+    {
+        $prefixedKeys = [];
+        foreach ($keys as $key) {
+            $prefixedKeys[] = $this->prefix . $key;
+        }
+
+        return $this->cache->deleteMultiple($prefixedKeys);
+    }
+
+    public function has($key)
+    {
+        return $this->cache->has($this->prefix . $key);
+    }
+}

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -166,14 +166,14 @@ class CacheTest extends TestCase
      * @dataProvider keyDataProvider
      *
      * @param mixed $key
-     * @param string $excepted
+     * @param string $expected
      */
-    public function testConstructorWithKeyPrefixAndGetOrSetWithOtherKeys($key, string $excepted): void
+    public function testConstructorWithKeyPrefixAndGetOrSetWithOtherKeys($key, string $expected): void
     {
-        $cache = new Cache($this->handler, null, 'prefix-');
+        $cache = new Cache($this->handler, null);
         $cache->getOrSet($key, static fn (): string => 'value');
         $items = $this->getItems($cache);
-        $this->assertSame("prefix-{$excepted}", $items["prefix-{$excepted}"]->key());
+        $this->assertSame($expected, $items[$expected]->key());
     }
 
     public function testGetOrSetThrowExceptionForInvalidKey(): void


### PR DESCRIPTION
This will give us ability to conveniently set the same prefix for both PSR-16 cache interface and our own interface.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | -
