### PR TITLE
Make `normalize()` method to static in `CacheKeyNormalizer::class`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0.1 under development
 
 - New #132: Add interface `SerializerInterface` for data serialization, and `PhpSerializer` implementation (@Gerych1984)
-- Enh #139: Make `normalize()` method to static in `CacheKeyNormalizer::class` (@terabytesoftw)
+- Chg #139: Make `normalize()` method static in `CacheKeyNormalizer` class (@terabytesoftw)
 
 ## 3.0.0 February 15, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.0.1 under development
 
 - New #132: Add interface `SerializerInterface` for data serialization, and `PhpSerializer` implementation (@Gerych1984)
+- Enh #139: Make `normalize()` method to static in `CacheKeyNormalizer::class` (@terabytesoftw)
 
 ## 3.0.0 February 15, 2023
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,12 @@
 # Upgrading Instructions for Yii Cache
 
-* Change method `normalize()` to static in `CacheKeyNormalizer` class.
+This file contains the upgrade notes. These notes highlight changes that could break your
+application when you upgrade the package from one version to another.
+
+> **Important!** The following upgrading instructions are cumulative. That is, if you want
+> to upgrade from version A to version C and there is version B between A and C, you need
+> to following the instructions for both A and B.
+
+## Upgrade from 3.x
+
+- Change method `normalize()` to static in `CacheKeyNormalizer` class.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,3 @@
+# Upgrading Instructions for Yii Cache
+
+* Change method `normalize()` to static in `CacheKeyNormalizer` class.

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -36,11 +36,6 @@ final class Cache implements CacheInterface
     private CacheItems $items;
 
     /**
-     * @var CacheKeyNormalizer Normalizes the cache key into a valid string.
-     */
-    private CacheKeyNormalizer $keyNormalizer;
-
-    /**
      * @var int|null The default TTL for a cache entry. null meaning infinity, negative or zero results in the
      * cache key deletion. This value is used by {@see getOrSet()}, if the duration is not explicitly given.
      */
@@ -56,7 +51,6 @@ final class Cache implements CacheInterface
     {
         $this->psr = new DependencyAwareCache($this, $handler);
         $this->items = new CacheItems();
-        $this->keyNormalizer = new CacheKeyNormalizer();
         $this->defaultTtl = $this->normalizeTtl($defaultTtl);
     }
 
@@ -72,7 +66,7 @@ final class Cache implements CacheInterface
         Dependency $dependency = null,
         float $beta = 1.0
     ) {
-        $key = $this->keyNormalizer->normalize($key);
+        $key = CacheKeyNormalizer::normalize($key);
         $value = $this->getValue($key, $beta);
 
         return $value ?? $this->setAndGet($key, $callable, $ttl, $dependency);
@@ -80,7 +74,7 @@ final class Cache implements CacheInterface
 
     public function remove(mixed $key): void
     {
-        $key = $this->keyNormalizer->normalize($key);
+        $key = CacheKeyNormalizer::normalize($key);
 
         if (!$this->psr->delete($key)) {
             throw new RemoveCacheException($key);

--- a/src/CacheKeyNormalizer.php
+++ b/src/CacheKeyNormalizer.php
@@ -34,7 +34,7 @@ final class CacheKeyNormalizer
      *
      * @return string The normalized cache key.
      */
-    public function normalize(mixed $key): string
+    public static function normalize(mixed $key): string
     {
         if (is_string($key) || is_int($key)) {
             $key = (string) $key;

--- a/tests/CacheKeyNormalizerTest.php
+++ b/tests/CacheKeyNormalizerTest.php
@@ -15,13 +15,6 @@ use function md5;
 
 final class CacheKeyNormalizerTest extends TestCase
 {
-    private CacheKeyNormalizer $normalizer;
-
-    protected function setUp(): void
-    {
-        $this->normalizer = new CacheKeyNormalizer();
-    }
-
     public function keyDataProvider(): array
     {
         return [
@@ -52,14 +45,14 @@ final class CacheKeyNormalizerTest extends TestCase
      */
     public function testNormalize(mixed $key, string $excepted): void
     {
-        $this->assertSame($excepted, $this->normalizer->normalize($key));
+        $this->assertSame($excepted, CacheKeyNormalizer::normalize($key));
     }
 
     public function testNormalizeThrowExceptionForInvalidKey(): void
     {
         $resource = fopen('php://memory', 'r');
         $this->expectException(InvalidArgumentException::class);
-        $this->normalizer->normalize($resource);
+        CacheKeyNormalizer::normalize($resource);
         fclose($resource);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
